### PR TITLE
Update elmio-js version to 1.0.2

### DIFF
--- a/elmio-tailwind/app_web/package-lock.json
+++ b/elmio-tailwind/app_web/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "elmio-js": "1.0.1"
+                "elmio-js": "1.0.2"
             },
             "devDependencies": {
                 "@biomejs/biome": "1.9.4",
@@ -18,9 +18,7 @@
                 "typescript": "5.6.3"
             },
             "engines": {
-                "node": ">=20.11.0",
-                "pnpm": "Please use npm",
-                "yarn": "Please use npm"
+                "node": ">=20.11.0"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -953,18 +951,16 @@
             "license": "MIT"
         },
         "node_modules/elmio-js": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/elmio-js/-/elmio-js-1.0.1.tgz",
-            "integrity": "sha512-YZ08M0IQAOcj+LqlMRe/mMCko+jR65O5BrwdNJz9eHW6N7ChHKrr1xAZjREwErlLh85mTC+hPMiY2I78jjZtdA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/elmio-js/-/elmio-js-1.0.2.tgz",
+            "integrity": "sha512-0CGNavjjLFNN1zyTKHRRm45WlIa5RXSCpEhORk5Snru+uAK/9Duh79MaG2zYN3lmN+4W7f9E9RSsEE9tAj6SWw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "fast-equals": "5.0.1",
                 "morphdom": "2.7.4"
             },
             "engines": {
-                "node": ">=20.11.0",
-                "npm": "Please use pnpm",
-                "yarn": "Please use pnpm"
+                "node": ">=20.11.0"
             }
         },
         "node_modules/emoji-regex": {

--- a/elmio-tailwind/app_web/package.json
+++ b/elmio-tailwind/app_web/package.json
@@ -34,6 +34,6 @@
         "node": ">=20.11.0"
     },
     "dependencies": {
-        "elmio-js": "1.0.1"
+        "elmio-js": "1.0.2"
     }
 }

--- a/elmio-tailwind/app_web/package.json
+++ b/elmio-tailwind/app_web/package.json
@@ -31,9 +31,7 @@
         "typescript": "5.6.3"
     },
     "engines": {
-        "node": ">=20.11.0",
-        "yarn": "Please use npm",
-        "pnpm": "Please use npm"
+        "node": ">=20.11.0"
     },
     "dependencies": {
         "elmio-js": "1.0.1"


### PR DESCRIPTION
This pull request updates the version of elmio-js to 1.0.2. The previous version was 1.0.1.